### PR TITLE
Fix for Dropbox Core API 5.2.2:

### DIFF
--- a/dropboxfs.py
+++ b/dropboxfs.py
@@ -168,7 +168,7 @@ class ChunkedReader(ContextManagerStream):
 
     def read(self, amt=None):
         """ Read a piece of the file from dropbox. """
-        if not self.r.isclosed():
+        if not self.r.closed:
             # Do some fake seeking
             if self.seek_pos < self.pos:
                 self.r.close()
@@ -215,7 +215,7 @@ class ChunkedReader(ContextManagerStream):
         more than once; only the first call, however, will have an effect.
         """
         # It's a memory leak if self.r not closed.
-        if not self.r.isclosed():
+        if not self.r.closed:
             self.r.close()
         if not self.closed:
             self.closed = True


### PR DESCRIPTION
Traceback (most recent call last):
  File "dropboxfs.py", line 667, in <module>
    main()
  File "dropboxfs.py", line 655, in main
    print filelike.read(100)
  File "dropboxfs.py", line 171, in read
    if not self.r.isclosed():
AttributeError: 'RESTResponse' object has no attribute 'isclosed'
