### PR TITLE
Update ChunkedReader to call super.__init__()

### DIFF
--- a/dropboxfs.py
+++ b/dropboxfs.py
@@ -133,6 +133,7 @@ class ChunkedReader(ContextManagerStream):
         self.closed = False
         self.pos = 0
         self.seek_pos = 0
+        super(ChunkedReader, self).__init__(self.r, name)
 
     def __len__(self):
         return self.bytes


### PR DESCRIPTION
This prevents a potential recursion error when calling things like fileno() that are not implemented in the inheritance chain (because of ContextManagerStream's overrided __getattr__())