### PR TITLE
Update Dropbox SDK as requested by Dropbox in email

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2017.4.17
 chardet==3.0.4
 coverage==4.4.1
-dropbox==7.3.1
+dropbox==8.0.0
 fs==0.5.4
 funcsigs==1.0.2
 idna==2.5


### PR DESCRIPTION
```
We are reaching out to you because we have discovered an issue with the
Dropbox API v2 Python SDK that your app is currently using. Although the
issue does not break any existing behavior, it limits our ability to
make non-breaking changes to our API endpoints going forward.

For that reason, we ask that you update your app to the latest version
of the SDK within the next two months. This bug was fixed specifically
in v8.0.0.
```