### PR TITLE
Return empty string on EOF

### DIFF
--- a/dropboxfs.py
+++ b/dropboxfs.py
@@ -169,6 +169,7 @@ class ChunkedReader(ContextManagerStream):
             return self.r.read(amt)
         else:
             self.close()
+            return ''
 
     def readline(self, size=-1):
         """ Not implemented. Read and return one line from the stream. """

--- a/tests/test_dropboxfs.py
+++ b/tests/test_dropboxfs.py
@@ -184,8 +184,9 @@ class TestChunkedReader(unittest.TestCase):
         self.assertEqual(131, self.reader.pos)
 
         self.reader.r.closed = True
-        self.reader.read()
+        data = self.reader.read()
         self.assertTrue(self.reader.closed)
+        self.assertEqual('', data)
 
     def test_readline(self):
         """Test reading a line of the file."""


### PR DESCRIPTION
Previously, this would return `None` which causes problems to the callers.